### PR TITLE
Adds additional information to the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "regular expressions for nom parsers"
 license = "MIT"
 keywords = ["parser", "parser-combinators", "regex"]
 categories = ["parsing"]
+repository = "https://github.com/rust-bakery/nom-regex
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ description = "regular expressions for nom parsers"
 license = "MIT"
 keywords = ["parser", "parser-combinators", "regex"]
 categories = ["parsing"]
-repository = "https://github.com/rust-bakery/nom-regex
+repository = "https://github.com/rust-bakery/nom-regex"
+readme = "README.md"
+documentation = "https://docs.rs/nom-regex"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Self-explanatory, but it just took me a moment to figure out where the repository was when I was looking at [the crate description](https://crates.io/crates/nom-regex/0.2.0).