### PR TITLE
Add repository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "regular expressions for nom parsers"
 license = "MIT"
 keywords = ["parser", "parser-combinators", "regex"]
 categories = ["parsing"]
+repository = "https://github.com/rust-bakery/nom-regex"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The listing on crates.io doesn't currently have any links to this repository.